### PR TITLE
fix: limit builds to 500

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -1,7 +1,10 @@
 /* maximum number of builds to show without folding */
 const MAX_VISIBLE_BUILDS = 12
 
-const extractArchiveBuilds = (builds) => {
+const extractArchiveBuilds = (allBuilds) => {
+  /* Limit builds to avoid exceeding GitHub's 65536 character comment size limit.
+   * https://docs.github.com/en/rest/issues/comments#update-an-issue-comment */
+  const builds = allBuilds.slice(-500)
   const latestStart = builds.findIndex(b => b.commit === builds[builds.length - 1].commit)
 
   /* try including second-to-latest commit if it fits */

--- a/test/comments.js
+++ b/test/comments.js
@@ -135,6 +135,19 @@ describe('Comments', () => {
       expect(body).to.include('<details>')
       expect(body).to.include('Click to see older builds (2)')
     })
+
+    it('should limit builds to 500 and drop oldest', async () => {
+      // 510 builds across 51 commits (10 each) - oldest 10 should be dropped
+      const commitSizes = Array(51).fill(10)
+      const manyBuilds = sample.getBuildsWithCommits(commitSizes)
+      db.getPRBuilds.returns(manyBuilds)
+      let body = await comments._renderComment({repo: 'test-repo', pr: 'PR-ID'})
+      // First commit (10 builds) should be dropped
+      expect(body).to.not.include('| COMMIT-0 |')
+      // Remaining commits should still be present
+      expect(body).to.include('| COMMIT-1 |')
+      expect(body).to.include('| COMMIT-50 |')
+    })
   })
 
   describe('_postComment', () => {


### PR DESCRIPTION
Github API has a body limit of 65536 characters and after that github-comment-manager just fails with :
```
 "data": {
           "message": "Validation Failed",
           "errors": [
           {
             "resource": "IssueComment",
             "code": "custom",
             "field": "body",
             "message": "body is too long (maximum is 65536 characters)"
           }
         ],
         "documentation_url":
"https://docs.github.com/rest/issues/comments#update-an-issue-comment",
         "status": "422"
       }
  },
```